### PR TITLE
Fix corner case when persisted events are deleted

### DIFF
--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
@@ -104,7 +104,7 @@ class InMemoryJournal extends AsyncWriteJournal with ActorLogging {
       val fromSeq = fromSequenceNr
       log.debug("Async read for highest sequence number for processorId: {} (hint, seek from  nr: {})", pid, fromSeq)
       journal.get(pid) match {
-        case None => 0
+        case None | Some(Nil) => 0
         case Some(list) => list.map(_.sequenceNr).max
       }
     }


### PR DESCRIPTION
Handle the case of having an empty but existing journal for a given pid.
This case happens after a persistent actor deletes all its events. 