### PR TITLE
Fix corner case when persisted events are deleted

### DIFF
--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
@@ -79,7 +79,7 @@ class JournalActor extends Actor {
       journal = journal.update(event)
       sender() ! JournalAck
 
-    case ReadHighestSequenceNr(persistenceId, fromSequenceNr) if journal.cache.isDefinedAt(persistenceId) =>
+    case ReadHighestSequenceNr(persistenceId, fromSequenceNr) if journal.cache.get(persistenceId).exists(_.nonEmpty) =>
       sender() ! ReadHighestSequenceNrResponse(journal.cache(persistenceId).map(_.sequenceNr).max)
 
     case ReadHighestSequenceNr(persistenceId, fromSequenceNr) =>


### PR DESCRIPTION
This is a regression of the case already fixed in https://github.com/dnvriend/akka-persistence-inmemory/pull/1