### PR TITLE
Initial implemenation of Persistence Query for In Memory journal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"   %% "akka-actor"                           % akkaVersion,
     "com.typesafe.akka"   %% "akka-slf4j"                           % akkaVersion,
     "com.typesafe.akka"   %% "akka-persistence"                     % akkaVersion,
+    "com.typesafe.akka"   %% "akka-persistence-query-experimental"  % akkaVersion,
     "com.typesafe.akka"   %% "akka-testkit"                         % akkaVersion     % "test",
     "com.typesafe.akka"   %% "akka-persistence-tck"                 % akkaVersion     % "test",
     "org.scalatest"       %% "scalatest"                            % "2.2.4"         % "test"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,6 +16,10 @@ akka {
 
 }
 
+inmemory-read-journal {
+  class = "akka.persistence.inmemory.query.InMemoryReadJournal"
+}
+
 inmemory-journal {
   class = "akka.persistence.inmemory.journal.InMemoryJournal"
 }

--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
@@ -16,10 +16,11 @@
 
 package akka.persistence.inmemory.journal
 
-import akka.actor.{ Actor, ActorLogging, ActorSystem, Props }
-import akka.pattern.ask
+import akka.actor._
+import akka.pattern._
+import akka.persistence.inmemory.journal.InMemoryJournal.{AllPersistenceIdsResponse, AllPersistenceIdsRequest}
 import akka.persistence.journal.AsyncWriteJournal
-import akka.persistence.{ AtomicWrite, PersistentRepr }
+import akka.persistence.{AtomicWrite, PersistentRepr}
 import akka.serialization.SerializationExtension
 import akka.util.Timeout
 
@@ -96,6 +97,9 @@ class JournalActor extends Actor {
 
     case ReplayMessages(persistenceId, fromSequenceNr, toSequenceNr, max) ⇒
       sender() ! ReplayMessagesResponse(Seq.empty)
+
+    case AllPersistenceIdsRequest =>
+      sender() ! AllPersistenceIdsResponse(journal.cache.keySet)
   }
 }
 
@@ -103,6 +107,11 @@ class InMemoryJournal extends AsyncWriteJournal with ActorLogging {
   implicit val timeout = Timeout(100.millis)
   implicit val ec = context.system.dispatcher
   val journal = context.actorOf(Props(new JournalActor))
+
+  override def receivePluginInternal = {
+    case AllPersistenceIdsRequest =>
+      (journal ? AllPersistenceIdsRequest) pipeTo sender()
+  }
 
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     log.debug("Async write messages: {}", messages)
@@ -125,4 +134,13 @@ class InMemoryJournal extends AsyncWriteJournal with ActorLogging {
       .mapTo[ReplayMessagesResponse]
       .map(_.messages.foreach(replayCallback))
   }
+}
+
+object InMemoryJournal {
+  final val Identifier = "inmemory-journal"
+
+  final case class AllPersistenceIdsResponse(allPersistenceIds: Set[String])
+
+  case object AllPersistenceIdsRequest
+
 }

--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
@@ -85,6 +85,7 @@ class JournalActor extends Actor {
       sender() ! ReadHighestSequenceNrResponse(journal.cache(persistenceId).map(_.sequenceNr).max)
 
     case ReadHighestSequenceNr(persistenceId, fromSequenceNr) ⇒
+      journal = journal.copy(cache = journal.cache + (persistenceId -> Nil))
       sender() ! ReadHighestSequenceNrResponse(0L)
 
     case ReplayMessages(persistenceId, fromSequenceNr, toSequenceNr, max) if journal.cache.isDefinedAt(persistenceId) ⇒

--- a/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
@@ -1,0 +1,37 @@
+package akka.persistence.inmemory.query
+
+import akka.actor.{ActorLogging, ActorRef, Props}
+import akka.persistence.Persistence
+import akka.persistence.inmemory.journal.InMemoryJournal
+import akka.persistence.query.journal.leveldb.DeliveryBuffer
+import akka.stream.actor.ActorPublisher
+import akka.stream.actor.ActorPublisherMessage.{Cancel, Request}
+
+class AllPersistenceIdsPublisher extends ActorPublisher[String] with DeliveryBuffer[String] with ActorLogging {
+
+  val journal: ActorRef = Persistence(context.system).journalFor(InMemoryJournal.Identifier)
+
+  def receive = init
+
+  def init: Receive = {
+    case _: Request ⇒
+      journal ! InMemoryJournal.AllPersistenceIdsRequest
+      context.become(active)
+    case Cancel ⇒ context.stop(self)
+  }
+
+  def active: Receive = {
+    case InMemoryJournal.AllPersistenceIdsResponse(allPersistenceIds) ⇒
+      buf ++= allPersistenceIds
+      deliverBuf()
+      if (buf.isEmpty) onCompleteThenStop()
+
+    case _: Request ⇒
+      deliverBuf()
+      if (buf.isEmpty) onCompleteThenStop()
+
+    case Cancel ⇒ context.stop(self)
+  }
+
+}
+

--- a/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
@@ -1,6 +1,22 @@
+/*
+ * Copyright 2015 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package akka.persistence.inmemory.query
 
-import akka.actor.{ActorLogging, ActorRef, Props}
+import akka.actor.{ActorLogging, ActorRef}
 import akka.persistence.Persistence
 import akka.persistence.inmemory.journal.InMemoryJournal
 import akka.persistence.query.journal.leveldb.DeliveryBuffer

--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
@@ -1,13 +1,34 @@
 package akka.persistence.inmemory.query
 
-import akka.persistence.query.{Hint, Query}
+import akka.actor.{ExtendedActorSystem, Props}
+import akka.persistence.query._
 import akka.persistence.query.scaladsl.ReadJournal
 import akka.stream.scaladsl.Source
+import akka.util.Timeout
+import com.typesafe.config.Config
+
+import scala.concurrent.duration.DurationInt
 
 object InMemoryReadJournal {
   final val Identifier = "inmemory-read-journal"
 }
 
-class InMemoryReadJournal extends ReadJournal {
-  override def query[T, M](q: Query[T, M], hints: Hint*): Source[T, M] = ???
+class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal {
+
+  implicit val timeout = Timeout(100.millis)
+  implicit val ec = system.dispatcher
+
+  override def query[T, M](q: Query[T, M], hints: Hint*): Source[T, M] = q match {
+    case AllPersistenceIds ⇒ allPersistenceIds(hints)
+    case unsupported ⇒ Source.failed[T](new UnsupportedOperationException(s"Query $unsupported not supported by ${getClass.getName}")).mapMaterializedValue(_ ⇒ noMaterializedValue)
+  }
+
+  def allPersistenceIds(hints: Seq[Hint]): Source[String, Unit] = {
+    Source.actorPublisher[String](Props[AllPersistenceIdsPublisher])
+      .mapMaterializedValue(_ ⇒ ())
+      .named("allPersistenceIds")
+  }
+
+  private def noMaterializedValue[M]: M = null.asInstanceOf[M]
+
 }

--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
@@ -1,0 +1,13 @@
+package akka.persistence.inmemory.query
+
+import akka.persistence.query.{Hint, Query}
+import akka.persistence.query.scaladsl.ReadJournal
+import akka.stream.scaladsl.Source
+
+object InMemoryReadJournal {
+  final val Identifier = "inmemory-read-journal"
+}
+
+class InMemoryReadJournal extends ReadJournal {
+  override def query[T, M](q: Query[T, M], hints: Hint*): Source[T, M] = ???
+}

--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package akka.persistence.inmemory.query
 
 import akka.actor.{ExtendedActorSystem, Props}

--- a/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
@@ -20,7 +20,7 @@ import akka.actor.Props
 import akka.event.LoggingReceive
 import akka.persistence.PersistentActor
 import akka.persistence.inmemory.TestSpec
-import akka.persistence.query.{AllPersistenceIds, PersistenceQuery}
+import akka.persistence.query.{EventsByPersistenceId, AllPersistenceIds, PersistenceQuery}
 import akka.stream.ActorMaterializer
 import akka.pattern._
 
@@ -50,12 +50,13 @@ class ReadJournalTest extends TestSpec {
     }
   }
 
+  implicit val mat = ActorMaterializer()
+
   "ReadJournal" should "support AllPersistenceIds" in {
     var actor1 = system.actorOf(Props(new MyActor(1)))
     var actor2 = system.actorOf(Props(new MyActor(2)))
 
     val readJournal = PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier)
-    implicit val mat = ActorMaterializer()
 
 //    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s)}.futureValue.sorted shouldBe List("my-1", "my-2")
 
@@ -67,5 +68,10 @@ class ReadJournalTest extends TestSpec {
 
     readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s)}.futureValue.sorted shouldBe List("my-1", "my-2")
   }
+
+//  it should "not support EventsByPersistenceId" in {
+//    val readJournal = PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier)
+//    readJournal.query(EventsByPersistenceId("1", 1L, 1L)).runFold(List[String]()) { (acc, ev) => acc.::(ev.event.asInstanceOf[String])}.futureValue.sorted shouldBe List("my-1", "my-2")
+//  }
 
 }

--- a/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.inmemory.query
+
+import akka.persistence.inmemory.TestSpec
+import akka.persistence.query.PersistenceQuery
+
+class ReadJournalTest extends TestSpec {
+
+  "ReadJournal" should "be OK" in {
+    PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier) should not be null
+  }
+
+}

--- a/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
@@ -58,7 +58,10 @@ class ReadJournalTest extends TestSpec {
 
     val readJournal = PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier)
 
-//    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s)}.futureValue.sorted shouldBe List("my-1", "my-2")
+    (actor1 ? "state").futureValue shouldBe 0
+    (actor2 ? "state").futureValue shouldBe 0
+
+    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s)}.futureValue.sorted shouldBe List("my-1", "my-2")
 
     actor1 ! 2
     (actor1 ? "state").futureValue shouldBe 2

--- a/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
@@ -18,18 +18,20 @@ package akka.persistence.inmemory.query
 
 import akka.actor.Props
 import akka.event.LoggingReceive
+import akka.pattern._
 import akka.persistence.PersistentActor
 import akka.persistence.inmemory.TestSpec
-import akka.persistence.query.{EventsByPersistenceId, AllPersistenceIds, PersistenceQuery}
+import akka.persistence.query.{AllPersistenceIds, PersistenceQuery}
 import akka.stream.ActorMaterializer
-import akka.pattern._
 
 class ReadJournalTest extends TestSpec {
+
+  implicit val mat = ActorMaterializer()
 
   class MyActor(id: Int) extends PersistentActor {
     override val persistenceId: String = "my-" + id
 
-    var state : Int = 0
+    var state: Int = 0
 
     override def receiveCommand: Receive = LoggingReceive {
       case "state" ⇒
@@ -50,8 +52,6 @@ class ReadJournalTest extends TestSpec {
     }
   }
 
-  implicit val mat = ActorMaterializer()
-
   "ReadJournal" should "support AllPersistenceIds" in {
     var actor1 = system.actorOf(Props(new MyActor(1)))
     var actor2 = system.actorOf(Props(new MyActor(2)))
@@ -61,7 +61,7 @@ class ReadJournalTest extends TestSpec {
     (actor1 ? "state").futureValue shouldBe 0
     (actor2 ? "state").futureValue shouldBe 0
 
-    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s)}.futureValue.sorted shouldBe List("my-1", "my-2")
+    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s) }.futureValue.sorted shouldBe List("my-1", "my-2")
 
     actor1 ! 2
     (actor1 ? "state").futureValue shouldBe 2
@@ -69,12 +69,12 @@ class ReadJournalTest extends TestSpec {
     actor2 ! 3
     (actor2 ? "state").futureValue shouldBe 3
 
-    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s)}.futureValue.sorted shouldBe List("my-1", "my-2")
+    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s) }.futureValue.sorted shouldBe List("my-1", "my-2")
   }
 
-//  it should "not support EventsByPersistenceId" in {
-//    val readJournal = PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier)
-//    readJournal.query(EventsByPersistenceId("1", 1L, 1L)).runFold(List[String]()) { (acc, ev) => acc.::(ev.event.asInstanceOf[String])}.futureValue.sorted shouldBe List("my-1", "my-2")
-//  }
+  //  it should "not support EventsByPersistenceId" in {
+  //    val readJournal = PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier)
+  //    readJournal.query(EventsByPersistenceId("1", 1L, 1L)).runFold(List[String]()) { (acc, ev) => acc.::(ev.event.asInstanceOf[String])}.futureValue.sorted shouldBe List("my-1", "my-2")
+  //  }
 
 }


### PR DESCRIPTION
Hello

This is a initial implementaiton that is intended to be a starting point for `Persistence Query` support and planned to be later supplemented by new PRs.

* implementation is mocking behaviour of `LeveldbReadJournal`
* Only single command `AllPersistenceIds` is supported
* `AllPersistenceIds` query is not supporting refreshing, i.e. it queries current state of journal and doesn't watch for later changes
* `peristanceId` is put into journal cache with empty journal, so `AllPersistenceIds` returns all ids even if jourmal is empty
* test is written
