### PR TITLE
Initial implemenation of Persistence Query for In Memory journal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"   %% "akka-actor"                           % akkaVersion,
     "com.typesafe.akka"   %% "akka-slf4j"                           % akkaVersion,
     "com.typesafe.akka"   %% "akka-persistence"                     % akkaVersion,
+    "com.typesafe.akka"   %% "akka-persistence-query-experimental"  % akkaVersion,
     "com.typesafe.akka"   %% "akka-testkit"                         % akkaVersion     % "test",
     "com.typesafe.akka"   %% "akka-persistence-tck"                 % akkaVersion     % "test",
     "org.scalatest"       %% "scalatest"                            % "2.2.4"         % "test"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ akka {
 }
 
 inmemory-read-journal {
-  class = "akka.persistence.inmemory.query.InMemoryReadJournal"
+  class = "akka.persistence.inmemory.query.InMemoryReadJournalProvider"
 }
 
 inmemory-journal {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,6 +16,10 @@ akka {
 
 }
 
+inmemory-read-journal {
+  class = "akka.persistence.inmemory.query.InMemoryReadJournal"
+}
+
 inmemory-journal {
   full-serialization = off
   class = "akka.persistence.inmemory.journal.InMemoryJournal"

--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
@@ -17,7 +17,8 @@
 package akka.persistence.inmemory.journal
 
 import akka.actor._
-import akka.pattern.ask
+import akka.pattern._
+import akka.persistence.inmemory.journal.InMemoryJournal.{AllPersistenceIdsResponse, AllPersistenceIdsRequest}
 import akka.persistence.journal.AsyncWriteJournal
 import akka.persistence.{ Persistence, AtomicWrite, PersistentRepr }
 import akka.serialization.{ Serialization, SerializationExtension }
@@ -81,6 +82,7 @@ class JournalActor extends Actor {
       sender() ! ReadHighestSequenceNrResponse(journal.cache(persistenceId).map(_.sequenceNr).max)
 
     case ReadHighestSequenceNr(persistenceId, fromSequenceNr) ⇒
+      journal = journal.copy(cache = journal.cache + (persistenceId -> Nil))
       sender() ! ReadHighestSequenceNrResponse(0L)
 
     case ReplayMessages(persistenceId, fromSequenceNr, toSequenceNr, max) if journal.cache.isDefinedAt(persistenceId) ⇒
@@ -93,10 +95,19 @@ class JournalActor extends Actor {
 
     case ReplayMessages(persistenceId, fromSequenceNr, toSequenceNr, max) ⇒
       sender() ! ReplayMessagesResponse(Seq.empty)
+
+    case AllPersistenceIdsRequest =>
+      sender() ! AllPersistenceIdsResponse(journal.cache.keySet)
   }
 }
 
 object InMemoryJournal {
+  final val Identifier = "inmemory-journal"
+
+  final case class AllPersistenceIdsResponse(allPersistenceIds: Set[String])
+
+  case object AllPersistenceIdsRequest
+
   def marshal(repr: PersistentRepr)(implicit serialization: Serialization): Try[PersistentRepr] =
     serialization.serialize(repr.payload.asInstanceOf[AnyRef]).map(_ ⇒ repr)
 
@@ -124,6 +135,11 @@ class InMemoryJournal extends AsyncWriteJournal with ActorLogging {
   implicit val serialization: Serialization = SerializationExtension(context.system)
   val journal: ActorRef = context.actorOf(Props(new JournalActor))
   val doSerialize: Boolean = Persistence(context.system).journalConfigFor("inmemory-journal").getBoolean("full-serialization")
+
+  override def receivePluginInternal = {
+    case AllPersistenceIdsRequest =>
+      (journal ? AllPersistenceIdsRequest) pipeTo sender()
+  }
 
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     // every AtomicWrite contains a Seq[PersistentRepr], we have a sequence of AtomicWrite

--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
@@ -18,16 +18,16 @@ package akka.persistence.inmemory.journal
 
 import akka.actor._
 import akka.pattern._
-import akka.persistence.inmemory.journal.InMemoryJournal.{AllPersistenceIdsResponse, AllPersistenceIdsRequest}
+import akka.persistence.inmemory.journal.InMemoryJournal.{AllPersistenceIdsRequest, AllPersistenceIdsResponse}
 import akka.persistence.journal.AsyncWriteJournal
-import akka.persistence.{ Persistence, AtomicWrite, PersistentRepr }
-import akka.serialization.{ Serialization, SerializationExtension }
+import akka.persistence.{AtomicWrite, Persistence, PersistentRepr}
+import akka.serialization.{Serialization, SerializationExtension}
 import akka.util.Timeout
 
 import scala.collection.immutable.Seq
-import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
-import scala.util.{ Success, Failure, Try }
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 trait JournalEvent
 
@@ -129,7 +129,9 @@ object InMemoryJournal {
 }
 
 class InMemoryJournal extends AsyncWriteJournal with ActorLogging {
+
   import InMemoryJournal._
+
   implicit val timeout: Timeout = Timeout(100.millis)
   implicit val ec: ExecutionContext = context.system.dispatcher
   implicit val serialization: Serialization = SerializationExtension(context.system)
@@ -149,7 +151,7 @@ class InMemoryJournal extends AsyncWriteJournal with ActorLogging {
     val xsMarshalled: Seq[Try[WriteMessages]] = messages.map(atomicWrite ⇒ marshalAtomicWrite(atomicWrite, doSerialize))
     Future.sequence(xsMarshalled.map {
       case Success(xs) ⇒ writeToJournal(xs, journal)
-      case Failure(t)  ⇒ Future.successful(Failure(t))
+      case Failure(t) ⇒ Future.successful(Failure(t))
     })
   }
 

--- a/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.inmemory.query
+
+import akka.actor.{ActorLogging, ActorRef}
+import akka.persistence.Persistence
+import akka.persistence.inmemory.journal.InMemoryJournal
+import akka.persistence.query.journal.leveldb.DeliveryBuffer
+import akka.stream.actor.ActorPublisher
+import akka.stream.actor.ActorPublisherMessage.{Cancel, Request}
+
+class AllPersistenceIdsPublisher extends ActorPublisher[String] with DeliveryBuffer[String] with ActorLogging {
+
+  val journal: ActorRef = Persistence(context.system).journalFor(InMemoryJournal.Identifier)
+
+  def receive = init
+
+  def init: Receive = {
+    case _: Request ⇒
+      journal ! InMemoryJournal.AllPersistenceIdsRequest
+      context.become(active)
+    case Cancel ⇒ context.stop(self)
+  }
+
+  def active: Receive = {
+    case InMemoryJournal.AllPersistenceIdsResponse(allPersistenceIds) ⇒
+      buf ++= allPersistenceIds
+      deliverBuf()
+      if (buf.isEmpty) onCompleteThenStop()
+
+    case _: Request ⇒
+      deliverBuf()
+      if (buf.isEmpty) onCompleteThenStop()
+
+    case Cancel ⇒ context.stop(self)
+  }
+
+}
+

--- a/src/main/scala/akka/persistence/inmemory/query/EventsByPersistenceIdPublisher.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/EventsByPersistenceIdPublisher.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.inmemory.query
+
+import akka.actor.{ActorLogging, Props}
+import akka.persistence.JournalProtocol.{RecoverySuccess, ReplayMessages, ReplayMessagesFailure, ReplayedMessage}
+import akka.persistence.Persistence
+import akka.persistence.inmemory.journal.InMemoryJournal
+import akka.persistence.query.EventEnvelope
+import akka.persistence.query.journal.leveldb._
+import akka.stream.actor.ActorPublisher
+import akka.stream.actor.ActorPublisherMessage.{Cancel, Request}
+
+object EventsByPersistenceIdPublisher {
+  def props(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, maxBufSize: Int): Props = {
+    Props(new CurrentEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, maxBufSize))
+  }
+}
+
+case object Continue
+
+abstract class AbstractEventsByPersistenceIdPublisher(val persistenceId: String, val fromSequenceNr: Long, val maxBufSize: Int)
+  extends ActorPublisher[EventEnvelope] with DeliveryBuffer[EventEnvelope] with ActorLogging {
+
+  val journal = Persistence(context.system).journalFor(InMemoryJournal.Identifier)
+
+  var currSeqNo = fromSequenceNr
+
+  def toSequenceNr: Long
+
+  def receive = init
+
+  def init: Receive = {
+    case _: Request ⇒ receiveInitialRequest()
+    case Continue ⇒ // skip, wait for first Request
+    case Cancel ⇒ context.stop(self)
+  }
+
+  def receiveInitialRequest(): Unit
+
+  def idle: Receive = {
+    case Continue ⇒
+      if (timeForReplay)
+        replay()
+
+    case _: Request ⇒
+      receiveIdleRequest()
+
+    case Cancel ⇒
+      context.stop(self)
+  }
+
+  def timeForReplay: Boolean =
+    (buf.isEmpty || buf.size <= maxBufSize / 2) && (currSeqNo <= toSequenceNr)
+
+  def replay(): Unit = {
+    val limit = maxBufSize - buf.size
+    log.debug("request replay for persistenceId [{}] from [{}] to [{}] limit [{}]", persistenceId, currSeqNo, toSequenceNr, limit)
+    journal ! ReplayMessages(currSeqNo, toSequenceNr, limit, persistenceId, self)
+    context.become(replaying(limit))
+  }
+
+  def replaying(limit: Int): Receive = {
+    case ReplayedMessage(p) ⇒
+      buf :+= EventEnvelope(
+        offset = p.sequenceNr,
+        persistenceId = persistenceId,
+        sequenceNr = p.sequenceNr,
+        event = p.payload)
+      currSeqNo = p.sequenceNr + 1
+      deliverBuf()
+
+    case RecoverySuccess(highestSeqNr) ⇒
+      log.debug("replay completed for persistenceId [{}], currSeqNo [{}]", persistenceId, currSeqNo)
+      receiveRecoverySuccess(highestSeqNr)
+
+    case ReplayMessagesFailure(cause) ⇒
+      log.debug("replay failed for persistenceId [{}], due to [{}]", persistenceId, cause.getMessage)
+      deliverBuf()
+      onErrorThenStop(cause)
+
+    case _: Request ⇒
+      deliverBuf()
+
+    case Continue ⇒ // skip during replay
+
+    case Cancel ⇒
+      context.stop(self)
+  }
+
+  def receiveIdleRequest(): Unit
+
+  def receiveRecoverySuccess(highestSeqNr: Long): Unit
+}
+
+class CurrentEventsByPersistenceIdPublisher(persistenceId: String, fromSequenceNr: Long, var toSeqNr: Long, maxBufSize: Int)
+  extends AbstractEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, maxBufSize) {
+
+  override def receiveInitialRequest(): Unit = replay()
+
+  override def receiveIdleRequest(): Unit = {
+    deliverBuf()
+    if (buf.isEmpty && currSeqNo > toSequenceNr)
+      onCompleteThenStop()
+    else
+      self ! Continue
+  }
+
+  override def toSequenceNr: Long = toSeqNr
+
+  override def receiveRecoverySuccess(highestSeqNr: Long): Unit = {
+    deliverBuf()
+    if (highestSeqNr < toSequenceNr)
+      toSeqNr = highestSeqNr
+    if (highestSeqNr == 0L || (buf.isEmpty && currSeqNo > toSequenceNr))
+      onCompleteThenStop()
+    else
+      self ! Continue // more to fetch
+    context.become(idle)
+  }
+
+}

--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.inmemory.query
+
+import akka.actor.{ExtendedActorSystem, Props}
+import akka.persistence.query._
+import akka.persistence.query.scaladsl.ReadJournal
+import akka.stream.scaladsl.Source
+import akka.util.Timeout
+import com.typesafe.config.Config
+
+import scala.concurrent.duration.DurationInt
+
+object InMemoryReadJournal {
+  final val Identifier = "inmemory-read-journal"
+}
+
+class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal {
+
+  implicit val timeout = Timeout(100.millis)
+  implicit val ec = system.dispatcher
+
+  override def query[T, M](q: Query[T, M], hints: Hint*): Source[T, M] = q match {
+    case AllPersistenceIds ⇒ allPersistenceIds(hints)
+    case unsupported ⇒ Source.failed[T](new UnsupportedOperationException(s"Query $unsupported not supported by ${getClass.getName}")).mapMaterializedValue(_ ⇒ noMaterializedValue)
+  }
+
+  def allPersistenceIds(hints: Seq[Hint]): Source[String, Unit] = {
+    Source.actorPublisher[String](Props[AllPersistenceIdsPublisher])
+      .mapMaterializedValue(_ ⇒ ())
+      .named("allPersistenceIds")
+  }
+
+  private def noMaterializedValue[M]: M = null.asInstanceOf[M]
+
+}

--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
@@ -17,8 +17,8 @@
 package akka.persistence.inmemory.query
 
 import akka.actor.{ExtendedActorSystem, Props}
-import akka.persistence.query.ReadJournalProvider
-import akka.persistence.query.scaladsl.{CurrentPersistenceIdsQuery, ReadJournal}
+import akka.persistence.query.scaladsl.{CurrentEventsByPersistenceIdQuery, CurrentPersistenceIdsQuery, ReadJournal}
+import akka.persistence.query.{EventEnvelope, ReadJournalProvider}
 import akka.stream.scaladsl.Source
 import com.typesafe.config.Config
 
@@ -26,11 +26,19 @@ object InMemoryReadJournal {
   final val Identifier = "inmemory-read-journal"
 }
 
-class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal with CurrentPersistenceIdsQuery {
+class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal
+with CurrentPersistenceIdsQuery
+with CurrentEventsByPersistenceIdQuery {
   override def currentPersistenceIds(): Source[String, Unit] = {
     Source.actorPublisher[String](Props[AllPersistenceIdsPublisher])
       .mapMaterializedValue(_ ⇒ ())
-      .named("allPersistenceIds")
+      .named("currentPersistenceIds")
+  }
+
+  override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long = 0L, toSequenceNr: Long = Long.MaxValue) : Source[EventEnvelope, Unit] = {
+    Source.actorPublisher[EventEnvelope](EventsByPersistenceIdPublisher.props(persistenceId, fromSequenceNr, toSequenceNr, 100))
+      .mapMaterializedValue(_ ⇒ ())
+      .named(s"currentEventsByPersistenceId$persistenceId")
   }
 }
 

--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
@@ -17,34 +17,25 @@
 package akka.persistence.inmemory.query
 
 import akka.actor.{ExtendedActorSystem, Props}
-import akka.persistence.query._
-import akka.persistence.query.scaladsl.ReadJournal
+import akka.persistence.query.ReadJournalProvider
+import akka.persistence.query.scaladsl.{CurrentPersistenceIdsQuery, ReadJournal}
 import akka.stream.scaladsl.Source
-import akka.util.Timeout
 import com.typesafe.config.Config
-
-import scala.concurrent.duration.DurationInt
 
 object InMemoryReadJournal {
   final val Identifier = "inmemory-read-journal"
 }
 
-class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal {
-
-  implicit val timeout = Timeout(100.millis)
-  implicit val ec = system.dispatcher
-
-  override def query[T, M](q: Query[T, M], hints: Hint*): Source[T, M] = q match {
-    case AllPersistenceIds ⇒ allPersistenceIds(hints)
-    case unsupported ⇒ Source.failed[T](new UnsupportedOperationException(s"Query $unsupported not supported by ${getClass.getName}")).mapMaterializedValue(_ ⇒ noMaterializedValue)
-  }
-
-  def allPersistenceIds(hints: Seq[Hint]): Source[String, Unit] = {
+class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal with CurrentPersistenceIdsQuery {
+  override def currentPersistenceIds(): Source[String, Unit] = {
     Source.actorPublisher[String](Props[AllPersistenceIdsPublisher])
       .mapMaterializedValue(_ ⇒ ())
       .named("allPersistenceIds")
   }
-
-  private def noMaterializedValue[M]: M = null.asInstanceOf[M]
-
 }
+
+class InMemoryReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
+  override val scaladslReadJournal = new InMemoryReadJournal(system, config)
+  override val javadslReadJournal = null
+}
+

--- a/src/test/scala/akka/persistence/inmemory/journal/InMemoryJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/journal/InMemoryJournalTest.scala
@@ -22,7 +22,7 @@ import akka.pattern.ask
 import akka.persistence.PersistentActor
 import akka.persistence.inmemory.TestSpec
 
-class JournalTest extends TestSpec {
+class InMemoryJournalTest extends TestSpec {
 
   case class CounterState(counter: Long) {
     def update(event: String): CounterState = event match {

--- a/src/test/scala/akka/persistence/inmemory/journal/InMemoryJournalTestFullSerialization.scala
+++ b/src/test/scala/akka/persistence/inmemory/journal/InMemoryJournalTestFullSerialization.scala
@@ -28,7 +28,7 @@ class MyCmd(val inner: MyInnerCmd) extends Serializable
 
 class MyInnerCmd(val value: String)
 
-class JournalTestFullSerialization extends TestSpec {
+class InMemoryJournalTestFullSerialization extends TestSpec {
 
   class ObjectStateActor(id: Int) extends PersistentActor {
     var state: List[String] = Nil

--- a/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/ReadJournalTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.inmemory.query
+
+import akka.actor.Props
+import akka.event.LoggingReceive
+import akka.pattern._
+import akka.persistence.PersistentActor
+import akka.persistence.inmemory.TestSpec
+import akka.persistence.query.{AllPersistenceIds, PersistenceQuery}
+import akka.stream.ActorMaterializer
+
+class ReadJournalTest extends TestSpec {
+
+  implicit val mat = ActorMaterializer()
+
+  class MyActor(id: Int) extends PersistentActor {
+    override val persistenceId: String = "my-" + id
+
+    var state: Int = 0
+
+    override def receiveCommand: Receive = LoggingReceive {
+      case "state" ⇒
+        sender() ! state
+
+      case event: Int ⇒
+        persist(event) { (event: Int) ⇒
+          updateState(event)
+        }
+    }
+
+    def updateState(event: Int): Unit = {
+      state = state + event
+    }
+
+    override def receiveRecover: Receive = LoggingReceive {
+      case event: Int => updateState(event)
+    }
+  }
+
+  "ReadJournal" should "support AllPersistenceIds" in {
+    var actor1 = system.actorOf(Props(new MyActor(1)))
+    var actor2 = system.actorOf(Props(new MyActor(2)))
+
+    val readJournal = PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier)
+
+    (actor1 ? "state").futureValue shouldBe 0
+    (actor2 ? "state").futureValue shouldBe 0
+
+    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s) }.futureValue.sorted shouldBe List("my-1", "my-2")
+
+    actor1 ! 2
+    (actor1 ? "state").futureValue shouldBe 2
+
+    actor2 ! 3
+    (actor2 ? "state").futureValue shouldBe 3
+
+    readJournal.query(AllPersistenceIds).runFold(List[String]()) { (acc, s) => acc.::(s) }.futureValue.sorted shouldBe List("my-1", "my-2")
+  }
+
+  //  it should "not support EventsByPersistenceId" in {
+  //    val readJournal = PersistenceQuery(system).readJournalFor(InMemoryReadJournal.Identifier)
+  //    readJournal.query(EventsByPersistenceId("1", 1L, 1L)).runFold(List[String]()) { (acc, ev) => acc.::(ev.event.asInstanceOf[String])}.futureValue.sorted shouldBe List("my-1", "my-2")
+  //  }
+
+}


### PR DESCRIPTION
Hello

This is a initial implementation based on `RC3`, intended to be a starting point for `Persistence Query` support and planned to be later supplemented by new PRs.

* implementation is mocking behaviour of `LeveldbReadJournal`
* Only `currentPersistenceIds` and `currentEventsByPersistenceId` queries are supported
* `persistanceId` is put into journal cache with empty journal, so `CurrentPersistenceIdsQuery` returns all ids even if journal is empty
* tests are written
* test names are refactored
