### PR TITLE
"Live" version of allPersistenceIds

### DIFF
--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryJournal.scala
@@ -150,8 +150,8 @@ class InMemoryJournal extends AsyncWriteJournal with ActorLogging {
   override def receivePluginInternal = {
     case AllPersistenceIdsRequest ⇒
       journal.forward(AllPersistenceIdsRequest)
-//    case m: Terminated ⇒
-//      journal.forward(m)
+    case m: Terminated ⇒
+      journal.forward(m)
   }
 
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {

--- a/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/AllPersistenceIdsPublisher.scala
@@ -16,20 +16,14 @@
 
 package akka.persistence.inmemory.query
 
-import akka.actor.{Props, ActorLogging, ActorRef}
+import akka.actor.{ActorLogging, ActorRef}
 import akka.persistence.Persistence
 import akka.persistence.inmemory.journal.InMemoryJournal
-import akka.persistence.journal.leveldb.LeveldbJournal
-import akka.persistence.query.journal.leveldb.{AllPersistenceIdsPublisher, DeliveryBuffer}
+import akka.persistence.query.journal.leveldb.DeliveryBuffer
 import akka.stream.actor.ActorPublisher
 import akka.stream.actor.ActorPublisherMessage.{Cancel, Request}
 
-object AllPersistenceIdsPublisher {
-  def props(liveQuery: Boolean, maxBufSize: Int): Props =
-    Props(new AllPersistenceIdsPublisher(liveQuery, maxBufSize))
-}
-
-private[akka] class AllPersistenceIdsPublisher(liveQuery: Boolean, maxBufSize: Int)
+private[akka] class AllPersistenceIdsPublisher(liveQuery: Boolean)
   extends ActorPublisher[String] with DeliveryBuffer[String] with ActorLogging {
 
   val journal: ActorRef = Persistence(context.system).journalFor(InMemoryJournal.Identifier)

--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournal.scala
@@ -17,7 +17,7 @@
 package akka.persistence.inmemory.query
 
 import akka.actor.{ ExtendedActorSystem, Props }
-import akka.persistence.query.scaladsl.{ CurrentEventsByPersistenceIdQuery, CurrentPersistenceIdsQuery, ReadJournal }
+import akka.persistence.query.scaladsl.{AllPersistenceIdsQuery, CurrentEventsByPersistenceIdQuery, CurrentPersistenceIdsQuery, ReadJournal}
 import akka.persistence.query.{ EventEnvelope, ReadJournalProvider }
 import akka.stream.scaladsl.Source
 import com.typesafe.config.Config
@@ -28,9 +28,17 @@ object InMemoryReadJournal {
 
 class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal
     with CurrentPersistenceIdsQuery
+    with AllPersistenceIdsQuery
     with CurrentEventsByPersistenceIdQuery {
+
+  override def allPersistenceIds(): Source[String, Unit] = {
+    Source.actorPublisher[String](Props(classOf[AllPersistenceIdsPublisher], true))
+      .mapMaterializedValue(_ ⇒ ())
+      .named("allPersistenceIds")
+  }
+
   override def currentPersistenceIds(): Source[String, Unit] = {
-    Source.actorPublisher[String](Props[AllPersistenceIdsPublisher])
+    Source.actorPublisher[String](Props(classOf[AllPersistenceIdsPublisher], false))
       .mapMaterializedValue(_ ⇒ ())
       .named("currentPersistenceIds")
   }
@@ -40,6 +48,7 @@ class InMemoryReadJournal(system: ExtendedActorSystem, config: Config) extends R
       .mapMaterializedValue(_ ⇒ ())
       .named(s"currentEventsByPersistenceId$persistenceId")
   }
+
 }
 
 class InMemoryReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {

--- a/src/test/scala/akka/persistence/inmemory/query/InMemoryReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/InMemoryReadJournalTest.scala
@@ -95,35 +95,20 @@ class InMemoryReadJournalTest extends TestSpec {
   }
 
   it should "support allPersistenceIds" in {
-    val actor1 = system.actorOf(Props(new MyActor(1)))
-    val actor2 = system.actorOf(Props(new MyActor(2)))
-
-    (actor1 ? "state").futureValue shouldBe 0
-    (actor2 ? "state").futureValue shouldBe 0
-
     val source = allPersistenceIds(readJournal)
 
-    source.request(3)
-      .expectNextUnordered("my-1", "my-2")
-//      .expectComplete()
+    val actor1 = system.actorOf(Props(new MyActor(1)))
+    source.request(3).expectNext("my-1")
 
+    val actor2 = system.actorOf(Props(new MyActor(2)))
+    source.expectNext("my-2")
+
+    source.cancel()
     val actor3 = system.actorOf(Props(new MyActor(3)))
 
-    source.expectNext("my-3")
-      .cancel()
-      .expectComplete()
+    source.expectNoMsg()
 
-//    actor1 ! 2
-//    (actor1 ? "state").futureValue shouldBe 2
-//
-//    actor2 ! 3
-//    (actor2 ? "state").futureValue shouldBe 3
-//
-//    currentPersistenceIds(readJournal)
-//      .request(3)
-//      .expectNextUnordered("my-1", "my-2")
-//      .expectComplete()
-
+    cleanup(actor1, actor2, actor3)
   }
 
   it should "support currentEventsByPersistenceId" in {

--- a/src/test/scala/akka/persistence/inmemory/query/InMemoryReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/InMemoryReadJournalTest.scala
@@ -111,6 +111,22 @@ class InMemoryReadJournalTest extends TestSpec {
     cleanup(actor1, actor2, actor3)
   }
 
+  it should "support allPersistenceIds with demand limitation" in {
+    val source = allPersistenceIds(readJournal)
+
+    val actor1 = system.actorOf(Props(new MyActor(1)))
+    source.request(1).expectNext("my-1")
+    source.expectNoMsg()
+
+    val actor2 = system.actorOf(Props(new MyActor(2)))
+    val actor3 = system.actorOf(Props(new MyActor(3)))
+
+    source.request(1).expectNext("my-2")
+    source.cancel().expectNoMsg()
+
+    cleanup(actor1, actor2, actor3)
+  }
+
   it should "support currentEventsByPersistenceId" in {
     val actor3 = system.actorOf(Props(new MyActor(3)))
     actor3 ! 1

--- a/src/test/scala/akka/persistence/inmemory/query/InMemoryReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/InMemoryReadJournalTest.scala
@@ -83,10 +83,10 @@ class InMemoryReadJournalTest extends TestSpec {
     actor2 ! 3
     (actor2 ? "state").futureValue shouldBe 3
 
-    currentPersistenceIds(readJournal)
-      .request(3)
-      .expectNextUnordered("my-1", "my-2")
-      .expectComplete()
+//    currentPersistenceIds(readJournal)
+//      .request(3)
+//      .expectNextUnordered("my-1", "my-2")
+//      .expectComplete()
 
     cleanup(actor1, actor2)
   }


### PR DESCRIPTION
Implementation of `akka.persistence.query.scaladsl.AllPersistenceIdsQuery` trait. 
Doesn't complete stream and keep publishing updates to query.