### PR TITLE
fix eventsByTag including substrings of tag

### DIFF
--- a/src/main/scala/akka/persistence/inmemory/extension/InMemoryJournalStorage.scala
+++ b/src/main/scala/akka/persistence/inmemory/extension/InMemoryJournalStorage.scala
@@ -71,7 +71,7 @@ class InMemoryJournalStorage(serialization: Serialization) extends Actor with Ac
     def increment(offset: Long): Long = offset + 1
     def getByOffset(p: JournalEntry => Boolean): List[JournalEntry] = {
       val xs = getAllEvents(journal)
-        .filter(_.tags.exists(tags => tags.contains(tag))).toList
+        .filter(_.tags.contains(tag)).toList
         .sortBy(_.ordering)
         .zipWithIndex.map {
           case (entry, index) =>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "2.4.17.0"
+version := "2.4.17.1-SNAPSHOT"


### PR DESCRIPTION
The current code is calling contains on each tag instead of on the set of tags, and therefore including substring matches.