### PR TITLE
Adds support for keyspace similar to akka-persistence-cassandra

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ trait InMemoryCleanup extends BeforeAndAfterEach { _: Suite =>
 
   override protected def beforeEach(): Unit = {
     val tp = TestProbe()
-    tp.send(StorageExtension(system).journalStorage, InMemoryJournalStorage.ClearJournal)
+    tp.send(StorageExtension(system).journalStorage(), InMemoryJournalStorage.ClearJournal)
     tp.expectMsg(akka.actor.Status.Success(""))
-    tp.send(StorageExtension(system).snapshotStorage, InMemorySnapshotStorage.ClearSnapshots)
+    tp.send(StorageExtension(system).snapshotStorage(), InMemorySnapshotStorage.ClearSnapshots)
     tp.expectMsg(akka.actor.Status.Success(""))
     super.beforeEach()
   }

--- a/src/main/scala/akka/persistence/inmemory/journal/InMemoryAsyncWriteJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/journal/InMemoryAsyncWriteJournal.scala
@@ -43,7 +43,7 @@ class InMemoryAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
   implicit val timeout: Timeout = Timeout(config.getDuration("ask-timeout", TimeUnit.SECONDS) -> SECONDS)
   val serialization = SerializationExtension(system)
 
-  val journal: ActorRef = StorageExtension(system).journalStorage
+  val journal: ActorRef = StorageExtension(system).journalStorage(StorageExtension.keyspaceFrom(config))
 
   private def serialize(persistentRepr: PersistentRepr): Try[(Array[Byte], Set[String])] = persistentRepr.payload match {
     case Tagged(payload, tags) =>

--- a/src/main/scala/akka/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
@@ -56,7 +56,7 @@ class InMemoryReadJournal(config: Config)(implicit val system: ExtendedActorSyst
   private implicit val mat: Materializer = ActorMaterializer()
   private implicit val log: LoggingAdapter = Logging(system, this.getClass)
   private val serialization = SerializationExtension(system)
-  private val journal: ActorRef = StorageExtension(system).journalStorage
+  private val journal: ActorRef = StorageExtension(system).journalStorage(StorageExtension.keyspaceFrom(config))
   private val offsetMode: String = config.getString("offset-mode").toLowerCase()
   private implicit val timeout: Timeout = Timeout(config.getDuration("ask-timeout", TimeUnit.MILLISECONDS) -> MILLISECONDS)
   private val refreshInterval: FiniteDuration = config.getDuration("refresh-interval", TimeUnit.MILLISECONDS) -> MILLISECONDS

--- a/src/main/scala/akka/persistence/inmemory/snapshot/InMemorySnapshotStore.scala
+++ b/src/main/scala/akka/persistence/inmemory/snapshot/InMemorySnapshotStore.scala
@@ -42,7 +42,7 @@ class InMemorySnapshotStore(config: Config) extends SnapshotStore {
   implicit val timeout: Timeout = Timeout(config.getDuration("ask-timeout", TimeUnit.SECONDS) -> SECONDS)
   val serialization = SerializationExtension(system)
 
-  val snapshots: ActorRef = StorageExtension(system).snapshotStorage
+  val snapshots: ActorRef = StorageExtension(system).snapshotStorage(StorageExtension.keyspaceFrom(config))
 
   override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
     val SnapshotEntryOption: Future[Option[snapshotEntry]] = criteria match {

--- a/src/test/scala/akka/persistence/inmemory/query/KeyspaceTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/KeyspaceTest.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.persistence.inmemory.query
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.persistence.Persistence
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.scaladsl._
+import com.typesafe.config.{Config, ConfigFactory}
+
+class KeyspaceTest extends QueryTestSpec {
+  val withSomeKeyspaceConfig: Config = ConfigFactory.parseString(
+    """
+      |inmemory-journal {
+      |  # Name of the keyspace to be used by the plugin. Default value is none.
+      |  keyspace = "someKeyspace"
+      |}
+      |
+      |inmemory-read-journal {
+      |  # Name of the keyspace to be used by the plugin. Default value is none.
+      |  keyspace = "someKeyspace"
+      |}
+    """.stripMargin)
+
+  private val systemWithSomeKeyspace: ActorSystem = ActorSystem("test", withSomeKeyspaceConfig.withFallback(system.settings.config))
+  private lazy val journalWithSomeKeyspace: ActorRef = Persistence(systemWithSomeKeyspace).journalFor("inmemory-journal")
+  private lazy val readJournalSomeKeyspace = PersistenceQuery(systemWithSomeKeyspace).readJournalFor("inmemory-read-journal")
+      .asInstanceOf[ReadJournal with CurrentPersistenceIdsQuery]
+
+
+  it should "not find any persistenceIds for different keyspace" in {
+    persist("my-1")(journalWithSomeKeyspace)
+
+    withCurrentPersistenceIds() { tp =>
+      tp.request(1)
+      tp.expectComplete()
+    }
+  }
+
+  it should "find persistenceIds from same keyspace" in {
+    persist("my-1")(journalWithSomeKeyspace)
+    persist("my-2")(journalWithSomeKeyspace)
+    persist("my-3")(journalWithSomeKeyspace)
+
+    withCurrentPersistenceIds() { tp =>
+      tp.request(3)
+      tp.expectNextUnordered("my-1", "my-2", "my-3")
+      tp.expectComplete()
+    }(readJournalSomeKeyspace)
+  }
+}

--- a/src/test/scala/akka/persistence/inmemory/query/QueryPerfSpec.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/QueryPerfSpec.scala
@@ -32,7 +32,7 @@ class QueryPerfSpec extends QueryTestSpec {
 
   def allEventsFromJournal: Seq[Any] = {
     val start = Platform.currentTime
-    val xs = readJournal.currentEventsByPersistenceId("pid", 0, Long.MaxValue)
+    val xs = defaultReadJournal.currentEventsByPersistenceId("pid", 0, Long.MaxValue)
       .runWith(Sink.seq).futureValue
     val end = Platform.currentTime
     info(s"currrentEventsByPersistenceId for ${xs.size} events took: ${end - start} ms")
@@ -41,7 +41,7 @@ class QueryPerfSpec extends QueryTestSpec {
 
   def eventsFromJournal(numberOfEvents: Int): Seq[Any] = {
     val start = Platform.currentTime
-    val xs = readJournal.eventsByPersistenceId("pid", 0, Long.MaxValue)
+    val xs = defaultReadJournal.eventsByPersistenceId("pid", 0, Long.MaxValue)
       .take(numberOfEvents)
       .runWith(Sink.seq).futureValue
     val end = Platform.currentTime

--- a/src/test/scala/akka/persistence/inmemory/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/QueryTestSpec.scala
@@ -51,50 +51,50 @@ abstract class QueryTestSpec(config: String = "application.conf") extends TestSp
 
   def withTags(payload: Any, tags: String*) = Tagged(payload, Set(tags: _*))
 
-  lazy val journal: ActorRef = Persistence(system).journalFor("inmemory-journal")
+  implicit lazy val defaultJournal: ActorRef = Persistence(system).journalFor("inmemory-journal")
 
-  lazy val readJournal = PersistenceQuery(system).readJournalFor("inmemory-read-journal")
+  implicit lazy val defaultReadJournal = PersistenceQuery(system).readJournalFor("inmemory-read-journal")
     .asInstanceOf[ReadJournal with CurrentPersistenceIdsQuery with PersistenceIdsQuery with CurrentEventsByPersistenceIdQuery with CurrentEventsByTagQuery with EventsByPersistenceIdQuery with EventsByTagQuery]
 
-  def withCurrentPersistenceIds(within: FiniteDuration = 10.seconds)(f: TestSubscriber.Probe[String] => Unit): Unit = {
+  def withCurrentPersistenceIds(within: FiniteDuration = 10.seconds)(f: TestSubscriber.Probe[String] => Unit)(implicit readJournal: CurrentPersistenceIdsQuery): Unit = {
     val tp = readJournal.currentPersistenceIds().runWith(TestSink.probe[String])
     tp.within(within)(f(tp))
   }
 
-  def withPersistenceIds(within: FiniteDuration = 10.seconds)(f: TestSubscriber.Probe[String] => Unit): Unit = {
+  def withPersistenceIds(within: FiniteDuration = 10.seconds)(f: TestSubscriber.Probe[String] => Unit)(implicit readJournal: PersistenceIdsQuery): Unit = {
     val tp = readJournal.persistenceIds().runWith(TestSink.probe[String])
     tp.within(within)(f(tp))
   }
 
-  def withCurrentEventsByPersistenceId(within: FiniteDuration = 10.seconds)(persistenceId: String, fromSequenceNr: Long = 0, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withCurrentEventsByPersistenceId(within: FiniteDuration = 10.seconds)(persistenceId: String, fromSequenceNr: Long = 0, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit)(implicit readJournal: CurrentEventsByPersistenceIdQuery): Unit = {
     val tp = readJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
-  def withEventsByPersistenceId(within: FiniteDuration = 10.seconds)(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withEventsByPersistenceId(within: FiniteDuration = 10.seconds)(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit)(implicit readJournal: EventsByPersistenceIdQuery): Unit = {
     val tp = readJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
-  def withCurrentEventsByTag(within: FiniteDuration = 10.seconds)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withCurrentEventsByTag(within: FiniteDuration = 10.seconds)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit)(implicit readJournal: CurrentEventsByTagQuery): Unit = {
     val tp = readJournal.currentEventsByTag(tag, offset).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
-  def withEventsByTag(within: FiniteDuration = 10.seconds)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withEventsByTag(within: FiniteDuration = 10.seconds)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit)(implicit readJournal: EventsByTagQuery): Unit = {
     val tp = readJournal.eventsByTag(tag, offset).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
-  def currentEventsByTagAsList(tag: String, offset: Offset): List[EventEnvelope] =
+  def currentEventsByTagAsList(tag: String, offset: Offset)(implicit readJournal: CurrentEventsByTagQuery): List[EventEnvelope] =
     readJournal.currentEventsByTag(tag, offset).runWith(Sink.seq).futureValue.toList
 
   /**
    * Persists a single event for a persistenceId with optionally
    * a number of tags.
    */
-  def persist(pid: String, tags: String*): String = {
-    writeMessages(1, 1, pid, senderProbe.ref, writerUuid, tags: _*)
+  def persist(pid: String, tags: String*)(implicit journal : ActorRef): String = {
+    writeMessages(journal, 1, 1, pid, senderProbe.ref, writerUuid, tags: _*)
     pid
   }
 
@@ -105,12 +105,12 @@ abstract class QueryTestSpec(config: String = "application.conf") extends TestSp
    * persist a single event with seqno 3. The value associated with the
    * event is 'a-seqno' eg. persist(3, 3, pid, tags) will store value 'a-3'.
    */
-  def persist(from: Int, to: Int, pid: String, tags: String*): String = {
-    writeMessages(from, to, pid, senderProbe.ref, writerUuid, tags: _*)
+  def persist(from: Int, to: Int, pid: String, tags: String*)(implicit journal : ActorRef): String = {
+    writeMessages(journal, from, to, pid, senderProbe.ref, writerUuid, tags: _*)
     pid
   }
 
-  private def writeMessages(fromSnr: Int, toSnr: Int, pid: String, sender: ActorRef, writerUuid: String, tags: String*): Unit = {
+  private def writeMessages(journal: ActorRef ,fromSnr: Int, toSnr: Int, pid: String, sender: ActorRef, writerUuid: String, tags: String*): Unit = {
     def persistentRepr(sequenceNr: Long) =
       PersistentRepr(
         payload = if (tags.isEmpty) s"a-$sequenceNr" else Tagged(s"a-$sequenceNr", Set(tags: _*)),
@@ -145,7 +145,7 @@ abstract class QueryTestSpec(config: String = "application.conf") extends TestSp
    */
   def deleteMessages(persistenceId: String, toSequenceNr: Long = Long.MaxValue)(implicit waitAtMost: FiniteDuration = 1.second): Unit = {
     val probe = TestProbe()
-    journal ! DeleteMessagesTo(persistenceId, toSequenceNr, probe.ref)
+    defaultJournal ! DeleteMessagesTo(persistenceId, toSequenceNr, probe.ref)
     probe.expectMsgType[DeleteMessagesSuccess](waitAtMost)
   }
 
@@ -153,7 +153,7 @@ abstract class QueryTestSpec(config: String = "application.conf") extends TestSp
     import akka.pattern.ask
     senderProbe = TestProbe()
     _writerUuid = UUID.randomUUID.toString
-    (StorageExtension(system).journalStorage ? ClearJournal).toTry should be a 'success
+    (StorageExtension(system).journalStorage() ? ClearJournal).toTry should be a 'success
     super.beforeEach()
   }
 


### PR DESCRIPTION
In our product we use this great plugin as well when we start up the developers local servers. We have many applications running store their data in deployed environment in different cassandra keyspaces. In order to test all this applications together we need this feature as well local in memory.