### PR TITLE
Make InMemoryReadJournal more extensible

### DIFF
--- a/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournalProvider.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/InMemoryReadJournalProvider.scala
@@ -17,11 +17,12 @@
 package akka.persistence.inmemory.query
 
 import akka.actor.ExtendedActorSystem
+import akka.persistence.inmemory.extension.StorageExtension
 import akka.persistence.query.ReadJournalProvider
 import com.typesafe.config.Config
 
 class InMemoryReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
-  override val scaladslReadJournal = new scaladsl.InMemoryReadJournal(config)(system)
+  override val scaladslReadJournal = new scaladsl.InMemoryReadJournal(config, StorageExtension(system).journalStorage)(system)
 
   override val javadslReadJournal = new javadsl.InMemoryReadJournal(scaladslReadJournal)
 }

--- a/src/main/scala/akka/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
@@ -44,7 +44,7 @@ object InMemoryReadJournal {
   final val Identifier = "inmemory-read-journal"
 }
 
-class InMemoryReadJournal(config: Config)(implicit val system: ExtendedActorSystem) extends ReadJournal
+class InMemoryReadJournal(config: Config, journal: ActorRef)(implicit val system: ExtendedActorSystem) extends ReadJournal
   with CurrentPersistenceIdsQuery
   with AllPersistenceIdsQuery
   with CurrentEventsByPersistenceIdQuery
@@ -58,7 +58,6 @@ class InMemoryReadJournal(config: Config)(implicit val system: ExtendedActorSyst
   private implicit val mat: Materializer = ActorMaterializer()
   private implicit val log: LoggingAdapter = Logging(system, this.getClass)
   private val serialization = SerializationExtension(system)
-  private val journal: ActorRef = StorageExtension(system).journalStorage
   private val offsetMode: String = config.getString("offset-mode").toLowerCase()
   private implicit val timeout: Timeout = Timeout(config.getDuration("ask-timeout", TimeUnit.MILLISECONDS) -> MILLISECONDS)
   private val refreshInterval: FiniteDuration = config.getDuration("refresh-interval", TimeUnit.MILLISECONDS) -> MILLISECONDS


### PR DESCRIPTION
Hello,

Thanks for great work and the plugin. I would like to addres eg. https://github.com/dnvriend/akka-persistence-inmemory/issues/40. There is the way to write faulty journal that may be written on the top on yours plugin. The only one problem is that `InMemoryReadJournal` is not extensible, storage cannot be injected from the outside. Is there a chance to merge this PR and release new version with that change?