### PR TITLE
Provide nice Java API for clearing journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ trait InMemoryCleanup extends BeforeAndAfterEach { _: Suite =>
 }
 ```
 
+From Java:
+
+```java
+ActorRef actorRef = extension.journalStorage();
+
+InMemoryJournalStorage.ClearJournal clearJournal = InMemoryJournalStorage.clearJournal();
+tp.send(actorRef, clearJournal);
+tp.expectMsg(new Status.Success(""));
+
+InMemorySnapshotStorage.ClearSnapshots clearSnapshots = InMemorySnapshotStorage.clearSnapshots();
+tp.send(actorRef, clearSnapshots);
+tp.expectMsg(new Status.Success(""));
+```
+
 ## offset-mode
 akka-persistence-query introduces `akka.persistence.query.Offset`, an ADT that defines `akka.persistence.query.NoOffset`,
 `akka.persistence.query.Sequence` and `akka.persistence.query.TimeBasedUUID`. These offsets can be used when using the

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -19,8 +19,8 @@ object ProjectSettings extends AutoPlugin {
     description := "A plugin for storing events in an event journal akka-persistence-inmemory",
     startYear := Some(2014),
 
-    scalaVersion := "2.12.4",
-    crossScalaVersions := Seq("2.11.11", "2.12.4"),
+    scalaVersion := "2.12.6",
+    crossScalaVersions := Seq("2.11.11", "2.12.6"),
     crossVersion := CrossVersion.binary,
 
     licenses := Seq(("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))),

--- a/src/main/scala/akka/persistence/inmemory/extension/InMemoryJournalStorage.scala
+++ b/src/main/scala/akka/persistence/inmemory/extension/InMemoryJournalStorage.scala
@@ -38,7 +38,14 @@ object InMemoryJournalStorage {
   final case class Delete(persistenceId: String, toSequenceNr: Long) extends JournalCommand
   final case class GetJournalEntriesExceptDeleted(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long) extends JournalCommand
   final case class GetAllJournalEntries(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long) extends JournalCommand
-  case object ClearJournal extends JournalCommand
+
+  /**
+   * Java API
+   */
+  def clearJournal(): ClearJournal = ClearJournal
+
+  sealed abstract class ClearJournal
+  case object ClearJournal extends ClearJournal with JournalCommand
 
   def getPersistenceId(prod: (String, Vector[JournalEntry])): String = prod._1
   def getEntries(prod: (String, Vector[JournalEntry])): Vector[JournalEntry] = prod._2

--- a/src/main/scala/akka/persistence/inmemory/extension/InMemorySnapshotStorage.scala
+++ b/src/main/scala/akka/persistence/inmemory/extension/InMemorySnapshotStorage.scala
@@ -28,11 +28,18 @@ object InMemorySnapshotStorage {
   final case class DeleteUpToMaxSequenceNr(persistenceId: String, maxSequenceNr: Long) extends SnapshotCommand
   final case class DeleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long) extends SnapshotCommand
   final case class DeleteUpToMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long) extends SnapshotCommand
-  case object ClearSnapshots extends SnapshotCommand
   final case class Save(persistenceId: String, sequenceNr: Long, timestamp: Long, snapshot: Array[Byte]) extends SnapshotCommand
   final case class SnapshotForMaxSequenceNr(persistenceId: String, sequenceNr: Long) extends SnapshotCommand
   final case class SnapshotForMaxSequenceNrAndMaxTimestamp(persistenceId: String, sequenceNr: Long, timestamp: Long) extends SnapshotCommand
   final case class SnapshotForMaxTimestamp(persistenceId: String, timestamp: Long) extends SnapshotCommand
+
+  sealed abstract class ClearSnapshots
+  case object ClearSnapshots extends ClearSnapshots with SnapshotCommand
+
+  /**
+    * Java API
+    */
+  def clearSnapshots(): ClearSnapshots = ClearSnapshots
 }
 
 class InMemorySnapshotStorage extends Actor with ActorLogging {

--- a/src/main/scala/akka/persistence/inmemory/extension/StorageExtension.scala
+++ b/src/main/scala/akka/persistence/inmemory/extension/StorageExtension.scala
@@ -23,6 +23,11 @@ object StorageExtension extends ExtensionId[StorageExtensionImpl] with Extension
   override def createExtension(system: ExtendedActorSystem): StorageExtensionImpl = new StorageExtensionImpl()(system)
 
   override def lookup(): ExtensionId[_ <: Extension] = StorageExtension
+
+  /**
+   * Java API
+   */
+  override def get(as: ActorSystem): StorageExtensionImpl = apply(as)
 }
 
 class StorageExtensionImpl()(implicit val system: ExtendedActorSystem) extends Extension {

--- a/src/test/java/akka/persistence/inmemory/StorageExtensionCompileOnlyTest.java
+++ b/src/test/java/akka/persistence/inmemory/StorageExtensionCompileOnlyTest.java
@@ -1,0 +1,28 @@
+package akka.persistence.inmemory;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Status;
+import akka.persistence.inmemory.extension.InMemoryJournalStorage;
+import akka.persistence.inmemory.extension.InMemorySnapshotStorage;
+import akka.persistence.inmemory.extension.StorageExtension;
+import akka.persistence.inmemory.extension.StorageExtensionImpl;
+import akka.testkit.TestProbe;
+
+public class StorageExtensionCompileOnlyTest {
+
+    public void shouldHaveANiceJavaAPI() {
+        ActorSystem actorSystem = ActorSystem.create();
+        TestProbe tp = new TestProbe(actorSystem);
+        StorageExtensionImpl extension = StorageExtension.get(actorSystem);
+
+        InMemoryJournalStorage.ClearJournal clearJournal = InMemoryJournalStorage.clearJournal();
+        ActorRef actorRef = extension.journalStorage();
+        tp.send(actorRef, clearJournal);
+        tp.expectMsg(new Status.Success(""));
+
+        InMemorySnapshotStorage.ClearSnapshots clearSnapshots = InMemorySnapshotStorage.clearSnapshots();
+        tp.send(actorRef, clearSnapshots);
+        tp.expectMsg(new Status.Success(""));
+    }
+}


### PR DESCRIPTION
As it is a case object and the objects live within an object is is hard to use them from Java.

Also the type is lost when looking up the extension unless you override get().

This is the pattern we follow in the Akka code base.