### PR TITLE
issues/55 fixed.

### DIFF
--- a/src/main/scala/akka/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
+++ b/src/main/scala/akka/persistence/inmemory/query/scaladsl/InMemoryReadJournal.scala
@@ -18,6 +18,7 @@ package akka.persistence.inmemory
 package query
 package scaladsl
 
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import akka.NotUsed
@@ -137,7 +138,7 @@ class InMemoryReadJournal(config: Config)(implicit val system: ExtendedActorSyst
       def nextFromOffset(xs: Seq[EventEnvelope]): Offset = {
         if (xs.isEmpty) from else xs.last.offset match {
           case Sequence(n)         => Sequence(n)
-          case TimeBasedUUID(time) => TimeBasedUUID(UUIDs.startOf(UUIDs.unixTimestamp(time) + 1))
+          case TimeBasedUUID(time) => TimeBasedUUID(new UUID(UUIDs.makeMSB(time.timestamp() + 1), UUIDs.MIN_CLOCK_SEQ_AND_NODE))
         }
       }
       ticker.flatMapConcat(_ => currentEventsByTag(tag, from)

--- a/src/test/resources/uuid-offset-mode-buffer.conf
+++ b/src/test/resources/uuid-offset-mode-buffer.conf
@@ -1,0 +1,20 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "application"
+// set offset-mode to uuid (default = "sequence")
+inmemory-read-journal.offset-mode = "uuid"
+inmemory-read-journal.refresh-interval = "1ms"
+inmemory-read-journal.max-buffer-size = "3"
+akka.test.single-expect-default = "30s"

--- a/src/test/scala/akka/persistence/inmemory/query/EventsByTag2UUIDJournalBufferTest.scala
+++ b/src/test/scala/akka/persistence/inmemory/query/EventsByTag2UUIDJournalBufferTest.scala
@@ -1,0 +1,30 @@
+package akka.persistence.inmemory.query
+
+import akka.persistence.query.{EventEnvelope2, NoOffset, Offset, TimeBasedUUID}
+
+import scala.concurrent.duration._
+
+class EventsByTag2UUIDJournalBufferTest extends QueryTestSpec("uuid-offset-mode-buffer.conf") {
+
+  final val NoMsgTime: FiniteDuration = 500.millis
+  final val BatchSize: Int = 1000
+
+  // Attempt to reproduce https://github.com/dnvriend/akka-persistence-inmemory/issues/55
+  // This test may not fail even if implementation is broken, since it depends on timing and performance.
+  // To reproduce issue you perhaps need to play with test's configuration, but on my box it fails 10 out of 10.
+  // Successful run took about 11 seconds on my box.
+  it should "step over buffer's bound correctly" in {
+    persist(1, BatchSize, "my-1", "number")
+
+    withEventsByTag2(30.seconds)("number", NoOffset) { tp =>
+      tp.request(Int.MaxValue)
+      for (i <- 1 to BatchSize) {
+        tp.expectNextPF {
+          case EventEnvelope2(TimeBasedUUID(_), "my-1", seq, _) =>
+            seq shouldBe i
+        }
+      }
+      tp.expectNoMsg(NoMsgTime)
+    }
+  }
+}


### PR DESCRIPTION
The problem happened then buffer's bound stops in between of events with timeuuid like:
...
e3e99ed0-a21d-11e8-b31a-e9435a127f49 // A: last event which put into a buffer
e3e99ed1-a21d-11e8-b31a-e9435a127f49 // B: next one
...

InMemoryReadJournal::eventsByTag::nextFromOffset uses unix timestamp to calculate 'next' event:
case TimeBasedUUID(time) => TimeBasedUUID(UUIDs.startOf(UUIDs.unixTimestamp(time) + 1))

and it skips event B because both of them have same unix timestamp: 1534510989629, and 'next' uuid will be:
e3e9c5e0-a21d-11e8-b31a-e9435a127f49

The difference in nanoseconds:
137538037896290000 for A
137538037896290001 for B

Where it comes from ?
InMemoryAsyncWriteJournal uses following functions to generate timeuuid for an event:
  def nowUuid: UUID = UUIDs.timeBased()
  def getTimeBasedUUID: TimeBasedUUID = TimeBasedUUID(nowUuid)
  def timeBased(): UUID = {
    new UUID(makeMSB(UUIDUtil.getCurrentTimestamp()), ClockSeqAndNode)
  }

If we will take a look on UUIDUtil.getCurrentTimestamp more closely, we can see following:
    public static final AtomicLong lastTimestamp = new AtomicLong(0L);
    ...
            long now = fromUnixTimestamp(System.currentTimeMillis());
            long last = lastTimestamp.get();
            if (now > last) { ...
            } else { ...
                long candidate = last + 1;

So if two (or more) events are persisted in same millisecond, nanoseconds will be added to timeuuid. But they are not
taken into account when events are read from a journal.

PS: I also added the test for that scenario, unfortunately test is very depended on timing (performance)
and may NOT fail even with broken implementation.
I was able to choose parameters which gives me like ~100% failure rate.
I mean, the test never passed successfully with original implementation on my box
but I cannot guarantee that for other boxes.

(cherry picked from commit da779101645a01e9861df94eec7723c3afcc4ad9)